### PR TITLE
Allow npm run android:assembleRelease to finish without temporary rem…

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -19,3 +19,5 @@
 
 android.enableJetifier=true
 android.useAndroidX=true
+# Error: The file name must end with .xml or .png on release build.
+android.disableResourceValidation=true


### PR DESCRIPTION
…oving .svg files from the drawable ressources.

Signed-off-by: Jérôme Benoit <jerome.benoit@piment-noir.org>