### PR TITLE
Secure app when billing not configured (stripe key is null)

### DIFF
--- a/src/provider/CentralServerProvider.tsx
+++ b/src/provider/CentralServerProvider.tsx
@@ -919,20 +919,28 @@ export default class CentralServerProvider {
     this.buildPaging(paging, params);
     // Call
     const url = this.buildRestEndpointUrl(ServerRoute.REST_BILLING_PAYMENT_METHODS, { userID: params.currentUserID });
-    const result = await this.axiosInstance.get(url, {
-      headers: this.buildSecuredHeaders()
-    });
-    return result.data as DataResult<BillingPaymentMethod>;
+    try{
+      const result = await this.axiosInstance.get(url, {
+        headers: this.buildSecuredHeaders()
+      });
+      return result?.data as DataResult<BillingPaymentMethod>;
+    } catch (e) {
+      return null;
+    }
   }
 
   public async getBillingSettings(): Promise<BillingSettings> {
     // Build the URL
     const url = `${this.buildRestServerURL()}/${ServerRoute.REST_BILLING_SETTING}`;
     // Execute the REST Service
-    const result = await this.axiosInstance.get<BillingSettings>(url, {
-      headers: this.buildSecuredHeaders()
-    });
-    return result.data;
+    try {
+      const result = await this.axiosInstance.get<BillingSettings>(url, {
+        headers: this.buildSecuredHeaders()
+      });
+      return result.data;
+    } catch (error) {
+      return null;
+    }
   }
 
   /* eslint-disable @typescript-eslint/indent */

--- a/src/screens/payment-methods/PaymentMethods.tsx
+++ b/src/screens/payment-methods/PaymentMethods.tsx
@@ -19,6 +19,7 @@ import Constants from '../../utils/Constants';
 import Message from '../../utils/Message';
 import Utils from '../../utils/Utils';
 import computeStyleSheet from './PaymentMethodsStyle';
+import { BillingSettings } from '../../types/Setting';
 
 export interface Props extends BaseProps {}
 
@@ -30,6 +31,7 @@ interface State {
   refreshing?: boolean;
   loading?: boolean;
   deleteOperationsStates?: Record<string, boolean>;
+  billingSettings?: BillingSettings;
 }
 
 export default class PaymentMethods extends BaseScreen<Props, State> {
@@ -58,6 +60,10 @@ export default class PaymentMethods extends BaseScreen<Props, State> {
 
   public async componentDidMount(): Promise<void> {
     await super.componentDidMount();
+    const billingSettings: BillingSettings = await this.centralServerProvider.getBillingSettings();
+    if (billingSettings) {
+      this.setState({ billingSettings });
+    }
   }
 
   public async componentDidFocus() {
@@ -72,7 +78,7 @@ export default class PaymentMethods extends BaseScreen<Props, State> {
       };
       const paymentMethods = await this.centralServerProvider.getPaymentMethods(params, { skip, limit });
       // Get total number of records
-      if (paymentMethods.count === -1) {
+      if (paymentMethods?.count === -1) {
         const paymentMethodsNbrRecordsOnly = await this.centralServerProvider.getPaymentMethods(params, Constants.ONLY_RECORD_COUNT);
         paymentMethods.count = paymentMethodsNbrRecordsOnly.count;
       }
@@ -132,7 +138,7 @@ export default class PaymentMethods extends BaseScreen<Props, State> {
 
   public render = () => {
     const style = computeStyleSheet();
-    const { paymentMethods, count, skip, limit, refreshing, loading } = this.state;
+    const { paymentMethods, count, skip, limit, refreshing, loading, billingSettings } = this.state;
     const { navigation } = this.props;
     return (
       <Container style={style.container}>
@@ -149,9 +155,13 @@ export default class PaymentMethods extends BaseScreen<Props, State> {
           rightActionIcon={'menu'}
         />
         <View style={style.toolBar}>
-          <TouchableOpacity onPress={() => navigation.navigate('StripePaymentMethodCreationForm')} style={style.addPaymentMethodButton}>
-            <Icon type={'MaterialIcons'} name={'add'} style={style.icon} />
-          </TouchableOpacity>
+          {billingSettings?.stripe?.publicKey && (
+            <TouchableOpacity
+              onPress={() => navigation.navigate('StripePaymentMethodCreationForm', { billingSettings })}
+              style={style.addPaymentMethodButton}>
+              <Icon type={'MaterialIcons'} name={'add'} style={style.icon} />
+            </TouchableOpacity>
+          )}
         </View>
         {loading ? (
           <Spinner style={style.spinner} color="grey" />

--- a/src/screens/payment-methods/stripe/StripePaymentMethodCreationForm.tsx
+++ b/src/screens/payment-methods/stripe/StripePaymentMethodCreationForm.tsx
@@ -37,8 +37,14 @@ export default function StripePaymentMethodCreationForm(props: Props) {
     const csProvider = await ProviderFactory.getProvider();
     setProvider(csProvider);
     // Billing
-    const billingSettings: BillingSettings = await csProvider.getBillingSettings();
-    await initStripe({ publishableKey: billingSettings?.stripe?.publicKey });
+    const billingSettings: BillingSettings = Utils.getParamFromNavigation(
+      props.route,
+      'billingSettings',
+      null
+    ) as unknown as BillingSettings;
+    if (billingSettings?.stripe?.publicKey) {
+      await initStripe({ publishableKey: billingSettings?.stripe?.publicKey });
+    }
   }
 
   async function addPaymentMethod(): Promise<void> {


### PR DESCRIPTION
- Hide 'add' button for payment methods when strip API key is null (stripe not configured)
- Avoid app crash if stripe API key is still null