### PR TITLE
Fixed npe on localisation lat/long

### DIFF
--- a/src/screens/cars/Cars.tsx
+++ b/src/screens/cars/Cars.tsx
@@ -86,9 +86,9 @@ export default class Cars extends SelectableList<Car> {
       };
       const cars = await this.centralServerProvider.getCars(params, { skip, limit }, ['-createdOn']);
       // Get total number of records
-      if (cars.count === -1) {
+      if (cars?.count === -1) {
         const carsNbrRecordsOnly = await this.centralServerProvider.getCars(params, Constants.ONLY_RECORD_COUNT);
-        cars.count = carsNbrRecordsOnly.count;
+        cars.count = carsNbrRecordsOnly?.count;
       }
       return cars;
     } catch (error) {

--- a/src/screens/charging-stations/list/ChargingStations.tsx
+++ b/src/screens/charging-stations/list/ChargingStations.tsx
@@ -157,16 +157,16 @@ export default class ChargingStations extends BaseAutoRefreshScreen<Props, State
         ConnectorStatus: filters.connectorStatus,
         ConnectorType: filters.connectorType,
         WithSiteArea: true,
-        LocLatitude: showMap ? this.currentRegion?.latitude : currentLocation.latitude,
-        LocLongitude: showMap ? this.currentRegion?.longitude : currentLocation.longitude,
+        LocLatitude: showMap ? this.currentRegion?.latitude : currentLocation?.latitude,
+        LocLongitude: showMap ? this.currentRegion?.longitude : currentLocation?.longitude,
         LocMaxDistanceMeters: showMap ? Utils.computeMaxBoundaryDistanceKm(this.currentRegion) : null
       };
       // Get with the Site Area
       chargingStations = await this.centralServerProvider.getChargingStations(params, { skip, limit }, ['id']);
       // Get total number of records
-      if (chargingStations.count === -1) {
+      if (chargingStations?.count === -1) {
         const chargingStationsNbrRecordsOnly = await this.centralServerProvider.getChargingStations(params, Constants.ONLY_RECORD_COUNT);
-        chargingStations.count = chargingStationsNbrRecordsOnly.count;
+        chargingStations.count = chargingStationsNbrRecordsOnly?.count;
       }
     } catch (error) {
       // Other common Error

--- a/src/screens/invoices/Invoices.tsx
+++ b/src/screens/invoices/Invoices.tsx
@@ -60,9 +60,9 @@ export default class Invoices extends BaseScreen<Props, State> {
       // Get the invoices
       const invoices = await this.centralServerProvider.getInvoices({}, { skip, limit }, ['-createdOn']);
       // Get total number of records
-      if (invoices.count === -1) {
+      if (invoices?.count === -1) {
         const invoicesNbrRecordsOnly = await this.centralServerProvider.getInvoices({}, Constants.ONLY_RECORD_COUNT);
-        invoices.count = invoicesNbrRecordsOnly.count;
+        invoices.count = invoicesNbrRecordsOnly?.count;
       }
       return invoices;
     } catch (error) {

--- a/src/screens/payment-methods/PaymentMethods.tsx
+++ b/src/screens/payment-methods/PaymentMethods.tsx
@@ -86,7 +86,7 @@ export default class PaymentMethods extends SelectableList<BillingPaymentMethod>
       // Get total number of records
       if (paymentMethods?.count === -1) {
         const paymentMethodsNbrRecordsOnly = await this.centralServerProvider.getPaymentMethods(params, Constants.ONLY_RECORD_COUNT);
-        paymentMethods.count = paymentMethodsNbrRecordsOnly.count;
+        paymentMethods.count = paymentMethodsNbrRecordsOnly?.count;
       }
       return paymentMethods;
     } catch (error) {

--- a/src/screens/site-areas/SiteAreas.tsx
+++ b/src/screens/site-areas/SiteAreas.tsx
@@ -101,16 +101,16 @@ export default class SiteAreas extends BaseAutoRefreshScreen<Props, State> {
         SiteID: this.site?.id,
         Issuer: true,
         WithAvailableChargers: true,
-        LocLatitude: showMap ? this.currentRegion?.latitude : currentLocation.latitude,
-        LocLongitude: showMap ? this.currentRegion?.longitude : currentLocation.longitude,
+        LocLatitude: showMap ? this.currentRegion?.latitude : currentLocation?.latitude,
+        LocLongitude: showMap ? this.currentRegion?.longitude : currentLocation?.longitude,
         LocMaxDistanceMeters: showMap ? Utils.computeMaxBoundaryDistanceKm(this.currentRegion) : null
       };
       // Get the Site Areas
       const siteAreas = await this.centralServerProvider.getSiteAreas(params, { skip, limit }, ['name']);
       // Get total number of records
-      if (siteAreas.count === -1) {
+      if (siteAreas?.count === -1) {
         const sitesAreasNbrRecordsOnly = await this.centralServerProvider.getSiteAreas(params, Constants.ONLY_RECORD_COUNT);
-        siteAreas.count = sitesAreasNbrRecordsOnly.count;
+        siteAreas.count = sitesAreasNbrRecordsOnly?.count;
       }
       return siteAreas;
     } catch (error) {

--- a/src/screens/sites/Sites.tsx
+++ b/src/screens/sites/Sites.tsx
@@ -27,12 +27,6 @@ import standardLightLayout from '../../../assets/map/standard-light.png';
 import satelliteLayout from '../../../assets/map/satellite.png';
 import computeFabStyles from '../../components/fab/FabComponentStyles';
 import ThemeManager from '../../custom-theme/ThemeManager';
-import ConnectorStats from '../../types/ConnectorStats';
-import statusMarkerAvailable from '../../../assets/icon/charging_station_available.png';
-import statusMarkerChargingOrOccupied from '../../../assets/icon/charging_station_charging.png';
-import statusMarkerUnavailable from '../../../assets/icon/charging_station_unavailable.png';
-import computeConnectorStatusStyles
-  from '../../components/connector-status/ConnectorStatusComponentStyles';
 
 export interface Props extends BaseProps {}
 
@@ -99,16 +93,16 @@ export default class Sites extends BaseAutoRefreshScreen<Props, State> {
         Search: searchText,
         Issuer: true,
         WithAvailableChargers: true,
-        LocLatitude: showMap ? this.currentRegion?.latitude : currentLocation.latitude,
-        LocLongitude: showMap ? this.currentRegion?.longitude : currentLocation.longitude,
+        LocLatitude: showMap ? this.currentRegion?.latitude : currentLocation?.latitude,
+        LocLongitude: showMap ? this.currentRegion?.longitude : currentLocation?.longitude,
         LocMaxDistanceMeters: showMap ? Utils.computeMaxBoundaryDistanceKm(this.currentRegion) : null
       };
       // Get the Sites
       const sites = await this.centralServerProvider.getSites(params, { skip, limit }, ['name']);
       // Get total number of records
-      if (sites.count === -1) {
+      if (sites?.count === -1) {
         const sitesNbrRecordsOnly = await this.centralServerProvider.getSites(params, Constants.ONLY_RECORD_COUNT);
-        sites.count = sitesNbrRecordsOnly.count;
+        sites.count = sitesNbrRecordsOnly?.count;
       }
       return sites;
     } catch (error) {

--- a/src/screens/tags/Tags.tsx
+++ b/src/screens/tags/Tags.tsx
@@ -77,9 +77,9 @@ export default class Tags extends SelectableList<Tag> {
       // Get the Tags
       const tags = await this.centralServerProvider.getTags(params, { skip, limit }, [sorting ?? '-createdOn']);
       // Get total number of records
-      if (tags.count === -1) {
+      if (tags?.count === -1) {
         const tagsNbrRecordsOnly = await this.centralServerProvider.getTags(params, Constants.ONLY_RECORD_COUNT);
-        tags.count = tagsNbrRecordsOnly.count;
+        tags.count = tagsNbrRecordsOnly?.count;
       }
       return tags;
     } catch (error) {

--- a/src/screens/transactions/history/TransactionsHistory.tsx
+++ b/src/screens/transactions/history/TransactionsHistory.tsx
@@ -115,10 +115,10 @@ export default class TransactionsHistory extends BaseScreen<Props, State> {
       // Get active transaction
       const transactions = await this.centralServerProvider.getTransactions(params, { skip, limit }, ['-timestamp']);
       // Get total number of records
-      if (transactions.count === -1) {
+      if (transactions?.count === -1) {
         const transactionsNbrRecordsOnly = await this.centralServerProvider.getTransactions(params, Constants.ONLY_RECORD_COUNT);
-        transactions.count = transactionsNbrRecordsOnly.count;
-        transactions.stats = transactionsNbrRecordsOnly.stats;
+        transactions.count = transactionsNbrRecordsOnly?.count;
+        transactions.stats = transactionsNbrRecordsOnly?.stats;
       }
       return transactions;
     } catch (error) {

--- a/src/screens/transactions/in-progress/TransactionsInProgress.tsx
+++ b/src/screens/transactions/in-progress/TransactionsInProgress.tsx
@@ -89,9 +89,9 @@ export default class TransactionsInProgress extends BaseAutoRefreshScreen<Props,
       // Get the Transactions
       const transactions = await this.centralServerProvider.getTransactionsActive(params, { skip, limit }, ['-timestamp']);
       // Get total number of records
-      if (transactions.count === -1) {
+      if (transactions?.count === -1) {
         const transactionsNbrRecordsOnly = await this.centralServerProvider.getTransactionsActive(params, Constants.ONLY_RECORD_COUNT);
-        transactions.count = transactionsNbrRecordsOnly.count;
+        transactions.count = transactionsNbrRecordsOnly?.count;
       }
       return transactions;
     } catch (error) {

--- a/src/screens/users/list/Users.tsx
+++ b/src/screens/users/list/Users.tsx
@@ -66,9 +66,9 @@ export default class Users extends SelectableList<User> {
       };
       const users = await this.centralServerProvider.getUsers(params, { skip, limit }, ['name']);
       // Get total number of records
-      if (users.count === -1) {
+      if (users?.count === -1) {
         const usersNbrRecordsOnly = await this.centralServerProvider.getUsers(params, Constants.ONLY_RECORD_COUNT);
-        users.count = usersNbrRecordsOnly.count;
+        users.count = usersNbrRecordsOnly?.count;
       }
       return users;
     } catch (error) {

--- a/src/utils/Utils.tsx
+++ b/src/utils/Utils.tsx
@@ -7,12 +7,6 @@ import { NativeModules, Platform, ViewStyle } from 'react-native';
 import { showLocation } from 'react-native-map-link';
 import validate from 'validate.js';
 
-import statusMarkerAvailable from '../../assets/icon/charging_station_available.png';
-import statusMarkerChargingOrOccupied from '../../assets/icon/charging_station_charging.png';
-import statusMarkerFaulted from '../../assets/icon/charging_station_faulted.png';
-import statusMarkerPreparingOrFinishing from '../../assets/icon/charging_station_finishing.png';
-import statusMarkerSuspended from '../../assets/icon/charging_station_suspended.png';
-import statusMarkerUnavailable from '../../assets/icon/charging_station_unavailable.png';
 import Configuration from '../config/Configuration';
 import { buildCommonColor } from '../custom-theme/customCommonColor';
 import ThemeManager from '../custom-theme/ThemeManager';
@@ -727,7 +721,8 @@ export default class Utils {
       await centralServerProvider.triggerAutoLogin(navigation, fctRefresh);
     } else {
       // Error in code
-      Message.showError(I18n.t('general.unexpectedErrorBackend'));
+      centralServerProvider.sendErrorReport(null,  error.message, error.stack);
+      Message.showError(I18n.t('general.unexpectedError'));
     }
   }
 


### PR DESCRIPTION
- Fixed npe on localisation.latitude and localisation.longitude in case where localisation is null (never setted)
- Added other npe safeguards 
- Call Report Error endpoint when still an error 
- Use UnexpectedError instead of UnexpectedBackendError when error.request is null

Next Step : Find how to detect localization on/off changes without restarting the app