### PR TITLE
[PRIO] Fixed statistics

### DIFF
--- a/__tests__/I18nManagerTests.tsx
+++ b/__tests__/I18nManagerTests.tsx
@@ -5,7 +5,7 @@ import I18nManager, {
   FormatNumberOptions,
   MetricCompactEnum,
   NumberFormatCompactStyleEnum,
-  NumberFormatNotationEnum
+  NumberFormatNotationEnum, NumberFormatStyleEnum
 } from '../src/I18n/I18nManager';
 
 test('computeMetricCompact', () => {
@@ -208,5 +208,31 @@ test('formatNumberWithCompacts MinDigits', () => {
   expect(formattedNumber?.value).toEqual('1,200000457');
   expect(formattedNumber?.compact).toEqual('millones');
 });
+
+test('formatNumberWithCompacts Currency', () => {
+  let formatNumberOptions = {
+    style: NumberFormatStyleEnum.CURRENCY,
+    maximumFractionDigits: 0
+  } as FormatNumberOptions
+  let formattedNumber = I18nManager.formatNumberWithCompacts(1200000.00, formatNumberOptions, 'es');
+  expect(formattedNumber.value).toEqual('1.200.000');
+
+  formatNumberOptions.currency = null;
+  formattedNumber = I18nManager.formatNumberWithCompacts(1200000.00, formatNumberOptions, 'es');
+  expect(formattedNumber.value).toEqual('1.200.000');
+})
+
+test('formatNumberWithCompacts Unit', () => {
+  let formatNumberOptions = {
+    style: NumberFormatStyleEnum.UNIT,
+    maximumFractionDigits: 0
+  } as FormatNumberOptions
+  let formattedNumber = I18nManager.formatNumberWithCompacts(1200000.00, formatNumberOptions, 'es');
+  expect(formattedNumber.value).toEqual('1.200.000');
+
+  formatNumberOptions.unit = null;
+  formattedNumber = I18nManager.formatNumberWithCompacts(1200000.00, formatNumberOptions, 'es');
+  expect(formattedNumber.value).toEqual('1.200.000');
+})
 
 jest.unmock('../src/utils/Utils')

--- a/__tests__/I18nManagerTests.tsx
+++ b/__tests__/I18nManagerTests.tsx
@@ -235,4 +235,17 @@ test('formatNumberWithCompacts Unit', () => {
   expect(formattedNumber.value).toEqual('1.200.000');
 })
 
+test('formatNumberWithCompacts NullOptions', () => {
+  let formatNumberOptions = {
+    style: NumberFormatStyleEnum.UNIT,
+    unit: null,
+    currency: 'EUR',
+    compactStyle: null,
+    currencySign: null,
+    maximumFractionDigits: null
+  } as FormatNumberOptions
+  let formattedNumber = I18nManager.formatNumberWithCompacts(1200000.00, formatNumberOptions, 'es');
+  expect(formattedNumber.value).toEqual('1.200.000');
+})
+
 jest.unmock('../src/utils/Utils')

--- a/src/I18n/I18nManager.tsx
+++ b/src/I18n/I18nManager.tsx
@@ -166,10 +166,10 @@ export default class I18nManager {
       }
       return {
         value: this.concatenateNumberFormatParts(parts),
-        ...({currency: isCurrency && this.getNumberFormatPartValue(parts, NumberFormatSymbolsEnum.CURRENCY)}),
-        ...({unit: isUnit && this.getNumberFormatPartValue(parts, NumberFormatSymbolsEnum.UNIT)}),
-        ...({compact}),
-        ...({percentSign: isPercent && this.getNumberFormatPartValue(parts, NumberFormatSymbolsEnum.PERCENT_SIGN)})
+        ...(isCurrency && {currency: this.getNumberFormatPartValue(parts, NumberFormatSymbolsEnum.CURRENCY)}),
+        ...(isUnit && {unit: this.getNumberFormatPartValue(parts, NumberFormatSymbolsEnum.UNIT)}),
+        ...(compact && {compact}),
+        ...(isPercent && {percentSign: this.getNumberFormatPartValue(parts, NumberFormatSymbolsEnum.PERCENT_SIGN)})
       };
     } catch ( e ) {
       return null;

--- a/src/I18n/I18nManager.tsx
+++ b/src/I18n/I18nManager.tsx
@@ -23,6 +23,7 @@ import itJsonLanguage from './languages/it.json';
 import ptJsonLanguage from './languages/pt.json';
 
 export interface FormatNumberOptions extends Intl.NumberFormatOptions {
+  [option: string] : any;
   compactThreshold?: number;
   compactStyle?: NumberFormatCompactStyleEnum;
 }
@@ -121,35 +122,58 @@ export default class I18nManager {
 
   public static formatNumberWithCompacts(value: number, options: FormatNumberOptions = {}, locale: string = i18n.locale): FormatNumberResult {
     options = {... options };
-    const isCompactForm =
-      options.notation === NumberFormatNotationEnum.COMPACT &&
-      (!options.compactThreshold || (options.compactThreshold && value > options.compactThreshold));
-    const isCurrency = options.currency && options.style === NumberFormatStyleEnum.CURRENCY;
-    options.currency = options.currency || I18nManager.currency;
-    if(!options.currency) {
-      delete options.currency
-    }
-    const isUnit = options.unit && options.style === NumberFormatStyleEnum.UNIT;
-    const isPercent = options.style === NumberFormatStyleEnum.PERCENT;
 
-    if (!isCompactForm) {
+    // Check currency options
+    if (!options.currency) {
+      delete options.currency
+      delete options.currencySign
+      delete options.currencyDisplay
+      // Intl doc: If the style is "currency", currency option must be provided
+      if (options.style === NumberFormatStyleEnum.CURRENCY) {
+        delete options.style
+      }
+    }
+
+    // Check unit options
+    if (!options.unit) {
+      delete options.unit;
+      delete options.unitDisplay;
+      // Intl doc: If the style is "unit", unit option must be provided
+      if (options.style === NumberFormatStyleEnum.UNIT) {
+        delete options.style;
+      }
+    }
+
+    const isUnit = options.unit;
+    const isPercent = options.style === NumberFormatStyleEnum.PERCENT;
+    const isCurrency = options.currency;
+    const shouldCompact = !options.compactThreshold || (options.compactThreshold && value > options.compactThreshold);
+
+    if (!shouldCompact && options.notation === NumberFormatNotationEnum.COMPACT) {
       delete options.notation;
     }
-    // Format the given value with the given options
-    const parts = Intl.NumberFormat(locale, options).formatToParts(value);
 
-    // Compute the compact (prefix) if needed (Intl namespace does not supports metric compacts yet)
-    let compact = this.getNumberFormatPartValue(parts, NumberFormatSymbolsEnum.COMPACT);
-    if (isCompactForm && options.compactStyle === NumberFormatCompactStyleEnum.METRIC) {
-      compact = this.computeMetricCompact(value);
+    // Delete all unset options
+    Object.keys(options).forEach((option) => options[option] ?? delete options[option]);
+
+    // Format the given value with the given options
+    try {
+      const parts = Intl.NumberFormat(locale, options).formatToParts(value);
+      // Compute the compact (prefix) if needed (Intl namespace does not supports metric compacts yet)
+      let compact = this.getNumberFormatPartValue(parts, NumberFormatSymbolsEnum.COMPACT);
+      if (compact && options.compactStyle === NumberFormatCompactStyleEnum.METRIC) {
+        compact = this.computeMetricCompact(value);
+      }
+      return {
+        value: this.concatenateNumberFormatParts(parts),
+        ...({currency: isCurrency && this.getNumberFormatPartValue(parts, NumberFormatSymbolsEnum.CURRENCY)}),
+        ...({unit: isUnit && this.getNumberFormatPartValue(parts, NumberFormatSymbolsEnum.UNIT)}),
+        ...({compact}),
+        ...({percentSign: isPercent && this.getNumberFormatPartValue(parts, NumberFormatSymbolsEnum.PERCENT_SIGN)})
+      };
+    } catch ( e ) {
+      return null;
     }
-    return {
-      value: this.concatenateNumberFormatParts(parts),
-      currency: isCurrency && this.getNumberFormatPartValue(parts, NumberFormatSymbolsEnum.CURRENCY),
-      unit: isUnit && this.getNumberFormatPartValue(parts, NumberFormatSymbolsEnum.UNIT),
-      compact: isCompactForm && compact,
-      percentSign: isPercent && this.getNumberFormatPartValue(parts, NumberFormatSymbolsEnum.PERCENT_SIGN)
-    };
   }
 
   public static formatCurrency(value: number, currency?: string): string {


### PR DESCRIPTION
- Ensure statistics work when currency is not set
- Added safeguards in method formatNumberWithCompacts by deleting all null or undefined options and following Intl related documentation about options dependencies