### PR TITLE
getUserDefaultTagCar() with charging station ID

### DIFF
--- a/src/provider/CentralServerProvider.tsx
+++ b/src/provider/CentralServerProvider.tsx
@@ -776,12 +776,15 @@ export default class CentralServerProvider {
     return result.data;
   }
 
-  public async getUserDefaultTagCar(userID: string): Promise<UserDefaultTagCar> {
+  public async getUserDefaultTagCar(userID: string, chargingStationID: string): Promise<UserDefaultTagCar> {
     this.debugMethod('getUserDefaultTagCar');
     const url = this.buildRestEndpointUrl(ServerRoute.REST_USER_DEFAULT_TAG_CAR, { id: userID });
     const res = await this.axiosInstance.get(url, {
       headers: this.buildSecuredHeaders(),
-      params: { UserID: userID }
+      params: { 
+        UserID: userID, // Should be removed - already part of the URL path
+        ChargingStationID: chargingStationID // This information will soon be mandatory server-side
+      }
     });
     return res?.data as UserDefaultTagCar;
   }

--- a/src/screens/charging-stations/connector-details/ChargingStationConnectorDetails.tsx
+++ b/src/screens/charging-stations/connector-details/ChargingStationConnectorDetails.tsx
@@ -1216,12 +1216,7 @@ export default class ChargingStationConnectorDetails extends BaseAutoRefreshScre
       if (userDefaultTagCar?.car) {
         userDefaultTagCar.car.user = selectedUser;
       }
-      this.setState({ 
-        selectedCar: userDefaultTagCar?.car, 
-        selectedTag: userDefaultTagCar?.tag, 
-        tagCarLoading: false,
-        userDefaultTagCar
-      });
+      this.setState({ selectedCar: userDefaultTagCar?.car, selectedTag: userDefaultTagCar?.tag, tagCarLoading: false });
     } catch (error) {
       this.setState({ tagCarLoading: false });
     }

--- a/src/screens/charging-stations/connector-details/ChargingStationConnectorDetails.tsx
+++ b/src/screens/charging-stations/connector-details/ChargingStationConnectorDetails.tsx
@@ -343,7 +343,7 @@ export default class ChargingStationConnectorDetails extends BaseAutoRefreshScre
       userInactiveError = true;
     }
     // Get the default tag and car of the selected user (only to get errors codes)
-    const userDefaultTagCar = await this.getUserDefaultTagAndCar(selectedUser);
+    const userDefaultTagCar = await this.getUserDefaultTagAndCar(selectedUser, chargingStationID);
     // If error codes, disabled the button
     if (!Utils.isEmptyArray(userDefaultTagCar?.errorCodes)) {
       buttonDisabled = true;
@@ -998,9 +998,9 @@ export default class ChargingStationConnectorDetails extends BaseAutoRefreshScre
     );
   }
 
-  private async getUserDefaultTagAndCar(user: User): Promise<UserDefaultTagCar> {
+  private async getUserDefaultTagAndCar(user: User, chargingStationID: string): Promise<UserDefaultTagCar> {
     try {
-      return this.centralServerProvider?.getUserDefaultTagCar(user?.id as string);
+      return this.centralServerProvider?.getUserDefaultTagCar(user?.id as string, chargingStationID);
     } catch (error) {
       await Utils.handleHttpUnexpectedError(
         this.centralServerProvider,
@@ -1205,7 +1205,7 @@ export default class ChargingStationConnectorDetails extends BaseAutoRefreshScre
   private async loadSelectedUserDefaultTagAndCar(selectedUser: User): Promise<void> {
     this.setState({ tagCarLoading: true });
     try {
-      const userDefaultTagCar = await this.getUserDefaultTagAndCar(selectedUser);
+      const userDefaultTagCar = await this.getUserDefaultTagAndCar(selectedUser, this.state.chargingStation?.id);
       this.carModalRef.current?.resetInput();
       this.tagModalRef.current?.resetInput();
       // Temporary workaround to ensure that the default property is set (server-side changes are to be done)
@@ -1216,7 +1216,12 @@ export default class ChargingStationConnectorDetails extends BaseAutoRefreshScre
       if (userDefaultTagCar?.car) {
         userDefaultTagCar.car.user = selectedUser;
       }
-      this.setState({ selectedCar: userDefaultTagCar?.car, selectedTag: userDefaultTagCar?.tag, tagCarLoading: false });
+      this.setState({ 
+        selectedCar: userDefaultTagCar?.car, 
+        selectedTag: userDefaultTagCar?.tag, 
+        tagCarLoading: false,
+        userDefaultTagCar
+      });
     } catch (error) {
       this.setState({ tagCarLoading: false });
     }


### PR DESCRIPTION
The getUserDefaultTagCar() endpoint will soon have the charging station ID mandatory as URL parameter.
- parameter has been ID in order to check whether the site area has enabled the access control or not.

User with no payment method should be able to start a session when the "Access Control" flag is OFF.