### PR TITLE
No more need of double click on clickable element when input focused

### DIFF
--- a/src/components/list/ItemsList.tsx
+++ b/src/components/list/ItemsList.tsx
@@ -85,6 +85,7 @@ export default class ItemsList<T extends ListItem> extends React.Component<Props
         <FlatList
           data={data}
           style={style.flatList}
+          keyboardShouldPersistTaps={'always'}
           onStartShouldSetResponder={() => true}
           renderItem={({ item }) => {
             const isItemDisabled = !!disableItem?.(item);

--- a/src/screens/auth/login/Login.tsx
+++ b/src/screens/auth/login/Login.tsx
@@ -320,7 +320,7 @@ export default class Login extends BaseScreen<Props, State> {
       <View style={style.container}>
         {showNoTenantFoundDialog && this.renderNoTenantFoundDialog()}
         {showExitAppDialog && this.renderExitAppDialog()}
-        <ScrollView contentContainerStyle={style.scrollContainer}>
+        <ScrollView keyboardShouldPersistTaps={'always'} contentContainerStyle={style.scrollContainer}>
           <KeyboardAvoidingView style={style.keyboardContainer} behavior="padding">
             <AuthHeader navigation={this.props.navigation} tenantLogo={tenantLogo} />
             <TouchableOpacity style={[style.linksButton]} onPress={() => this.newUser()}>

--- a/src/screens/cars/AddCar.tsx
+++ b/src/screens/cars/AddCar.tsx
@@ -104,7 +104,7 @@ export default class AddCar extends BaseScreen<Props, State> {
           title={I18n.t('cars.addCarTitle')}
           navigation={navigation}
         />
-        <ScrollView style={style.scrollview} contentContainerStyle={style.content}>
+        <ScrollView keyboardShouldPersistTaps={'always'} style={style.scrollview} contentContainerStyle={style.content}>
           <Input
             label={`${I18n.t('cars.model')}*`}
             labelStyle={style.inputLabel}
@@ -139,7 +139,7 @@ export default class AddCar extends BaseScreen<Props, State> {
                 dropdownStyle={style.selectDropdown}
                 rowStyle={style.selectDropdownRow}
                 rowTextStyle={style.selectDropdownRowText}
-                renderDropdownIcon={() => <Icon type={'MaterialIcons'} name={'arrow-drop-down'} />}
+                renderDropdownIcon={() => <Icon style={style.dropdownIcon} type={'MaterialIcons'} name={'arrow-drop-down'} />}
                 onSelect={(carConverter: CarConverter) => this.setState({ selectedConverter: carConverter })}
               />
             )}


### PR DESCRIPTION
- Fixed issue where we needed two clicks on clickable elements (button, touchableOpacity, e.g on Login page or Transaction list) when the text input is focused 