### PR TITLE
Redirection

### DIFF
--- a/src/provider/CentralServerProvider.tsx
+++ b/src/provider/CentralServerProvider.tsx
@@ -147,7 +147,7 @@ export default class CentralServerProvider {
     });
   }
 
-  public async getTenantLogoBySubdomain(tenant: TenantConnection): Promise<string> {
+  public async getTenantLogoBySubdomain(tenant: TenantConnection = {} as TenantConnection): Promise<string> {
     this.debugMethod('getTenantLogoBySubdomain');
     let tenantLogo = null;
     // Call backend
@@ -172,8 +172,9 @@ export default class CentralServerProvider {
     return tenantLogo;
   }
 
-  public getCurrentTenantLogo(): string {
-    return this.tenantLogo;
+  public async getCurrentTenantLogo(): Promise<string> {
+    const currentTenantLogo = await this.getTenantLogoBySubdomain(this.tenant);
+    return currentTenantLogo;
   }
 
   public async triggerAutoLogin(navigation: NavigationContainerRef<any>, fctRefresh: () => void): Promise<void> {

--- a/src/provider/CentralServerProvider.tsx
+++ b/src/provider/CentralServerProvider.tsx
@@ -149,25 +149,23 @@ export default class CentralServerProvider {
 
   public async getTenantLogoBySubdomain(tenant: TenantConnection): Promise<string> {
     this.debugMethod('getTenantLogoBySubdomain');
-    let tenantLogo = this.tenantLogosCache.get(tenant.subdomain);
-    if (!tenantLogo) {
-      // Call backend
-      const result = await this.axiosInstance.get<any>(
-        this.buildUtilRestEndpointUrl(RESTServerRoute.REST_TENANT_LOGO, null, tenant),
-        {
-          headers: this.buildHeaders(),
-          responseType: 'arraybuffer',
-          params: {
-            Subdomain: tenant.subdomain
-          }
+    let tenantLogo = null;
+    // Call backend
+    const result = await this.axiosInstance.get<any>(
+      this.buildUtilRestEndpointUrl(RESTServerRoute.REST_TENANT_LOGO, null, tenant),
+      {
+        headers: this.buildHeaders(),
+        responseType: 'arraybuffer',
+        params: {
+          Subdomain: tenant.subdomain
         }
-      );
-      if (result.data) {
-        const base64Image = Buffer.from(result.data).toString('base64');
-        if (base64Image) {
-          tenantLogo = 'data:' + result.headers['content-type'] + ';base64,' + base64Image;
-          this.tenantLogosCache.set(tenant.subdomain, tenantLogo);
-        }
+      }
+    );
+    if (result.data) {
+      const base64Image = Buffer.from(result.data).toString('base64');
+      if (base64Image) {
+        tenantLogo = 'data:' + result.headers['content-type'] + ';base64,' + base64Image;
+        this.tenantLogosCache.set(`${tenant.subdomain}${tenant.endpoint?.endpoint}`, tenantLogo);
       }
     }
     this.tenantLogo = tenantLogo;

--- a/src/provider/CentralServerProvider.tsx
+++ b/src/provider/CentralServerProvider.tsx
@@ -358,13 +358,11 @@ export default class CentralServerProvider {
     await this.notificationManager.checkOnHoldNotification();
   }
 
-  public async getEndUserLicenseAgreement(tenantSubDomain: string, params: { Language: string }): Promise<Eula> {
+  public async getEndUserLicenseAgreement(params: { Language: string }): Promise<Eula> {
     this.debugMethod('getEndUserLicenseAgreement');
-    // Get the Tenant
-    const tenant = await this.getTenant(tenantSubDomain);
     // Call
     const result = await this.axiosInstance.get<any>(
-      `${this.buildRestServerAuthURL(tenant)}/${RESTServerRoute.REST_END_USER_LICENSE_AGREEMENT}`,
+      `${Configuration.AWS_REST_ENDPOINT_PROD}/v1/auth/${RESTServerRoute.REST_END_USER_LICENSE_AGREEMENT}`,
       {
         headers: this.buildHeaders(),
         params

--- a/src/screens/auth/eula/Eula.tsx
+++ b/src/screens/auth/eula/Eula.tsx
@@ -9,6 +9,8 @@ import BaseProps from '../../../types/BaseProps';
 import Utils from '../../../utils/Utils';
 import BaseScreen from '../../base-screen/BaseScreen';
 import computeStyleSheet from './EulaStyles';
+import { StatusCodes } from 'http-status-codes';
+import Message from '../../../utils/Message';
 
 export interface Props extends BaseProps {}
 
@@ -45,10 +47,8 @@ export default class Eula extends BaseScreen<Props, State> {
 
   public loadEndUserLicenseAgreement = async () => {
     const { i18nLanguage: i18nLanguage } = this.state;
-    // Get the first tenant for the EULA (same in all tenants)
-    const tenants = await this.centralServerProvider.getTenants();
     try {
-      const result: any = await this.centralServerProvider.getEndUserLicenseAgreement(tenants[0].subdomain, {
+      const result: any = await this.centralServerProvider.getEndUserLicenseAgreement({
         Language: i18nLanguage
       });
       this.setState({
@@ -56,8 +56,7 @@ export default class Eula extends BaseScreen<Props, State> {
         eulaTextHtml: result.text
       });
     } catch (error) {
-      // Other common Error
-      await Utils.handleHttpUnexpectedError(this.centralServerProvider, error, 'general.eulaUnexpectedError', this.props.navigation);
+      await Utils.handleHttpUnexpectedError(this.centralServerProvider, error, 'general.eulaUnexpectedError', this.props.navigation, null, async () => this.loadEndUserLicenseAgreement());
     }
   };
 

--- a/src/screens/auth/login/Login.tsx
+++ b/src/screens/auth/login/Login.tsx
@@ -269,7 +269,7 @@ export default class Login extends BaseScreen<Props, State> {
               break;
             default:
               // Other common Error
-              await Utils.handleHttpUnexpectedError(this.centralServerProvider, error, 'authentication.loginUnexpectedError');
+              await Utils.handleHttpUnexpectedError(this.centralServerProvider, error, 'authentication.loginUnexpectedError', null, null, async () => this.login());
           }
         }
       }
@@ -317,7 +317,7 @@ export default class Login extends BaseScreen<Props, State> {
     }
   };
 
-  public render() {
+  public render(): React.ReactElement {
     const style = computeStyleSheet();
     const formStyle = computeFormStyleSheet();
     const commonColor = Utils.getCurrentCommonColor();

--- a/src/screens/auth/login/Login.tsx
+++ b/src/screens/auth/login/Login.tsx
@@ -5,7 +5,6 @@ import React from 'react';
 import { BackHandler, Keyboard, KeyboardAvoidingView, ScrollView, TextInput, TouchableOpacity } from 'react-native';
 
 import DialogModal from '../../../components/modal/DialogModal';
-import ExitAppDialog from '../../../components/modal/exit-app/ExitAppDialog';
 import computeModalCommonStyle from '../../../components/modal/ModalCommonStyle';
 import computeFormStyleSheet from '../../../FormStyles';
 import BaseProps from '../../../types/BaseProps';
@@ -37,7 +36,6 @@ interface State {
   errorEmail?: Record<string, unknown>[];
   errorNewTenantName?: Record<string, unknown>[];
   errorNewTenantSubDomain?: Record<string, unknown>[];
-  showExitAppDialog: boolean;
   showNoTenantFoundDialog: boolean;
 }
 
@@ -92,7 +90,6 @@ export default class Login extends BaseScreen<Props, State> {
       loading: false,
       initialLoading: true,
       hidePassword: true,
-      showExitAppDialog: false,
       showNoTenantFoundDialog: false
     };
   }
@@ -321,14 +318,13 @@ export default class Login extends BaseScreen<Props, State> {
     const formStyle = computeFormStyleSheet();
     const commonColor = Utils.getCurrentCommonColor();
     const navigation = this.props.navigation;
-    const { tenantLogo, eula, loading, initialLoading, hidePassword, showExitAppDialog, showNoTenantFoundDialog } = this.state;
+    const { tenantLogo, eula, loading, initialLoading, hidePassword, showNoTenantFoundDialog } = this.state;
     // Render
     return initialLoading ? (
       <Spinner style={formStyle.spinner} color="grey" />
     ) : (
       <View style={style.container}>
         {showNoTenantFoundDialog && this.renderNoTenantFoundDialog()}
-        {showExitAppDialog && this.renderExitAppDialog()}
         <ScrollView keyboardShouldPersistTaps={'always'} contentContainerStyle={style.scrollContainer}>
           <KeyboardAvoidingView style={style.keyboardContainer} behavior="padding">
             <AuthHeader navigation={this.props.navigation} tenantLogo={tenantLogo} />
@@ -445,10 +441,6 @@ export default class Login extends BaseScreen<Props, State> {
       key: `${Utils.randomNumber()}`,
       openQRCode
     });
-  }
-
-  private renderExitAppDialog() {
-    return <ExitAppDialog close={() => this.setState({ showExitAppDialog: false })} />;
   }
 
   private renderNoTenantFoundDialog() {

--- a/src/screens/auth/reset-password/ResetPassword.tsx
+++ b/src/screens/auth/reset-password/ResetPassword.tsx
@@ -169,18 +169,9 @@ export default class ResetPassword extends BaseScreen<Props, State> {
             case StatusCodes.NOT_FOUND:
               Message.showError(I18n.t('authentication.resetPasswordHashNotValid'));
               break;
-            case StatusCodes.MOVED_TEMPORARILY:
-              const newURLDomain = error?.response?.data?.errorDetailedMessage?.redirectDomain;
-              try {
-                await Utils.redirectTenant(newURLDomain, tenantSubDomain);
-                this.resetPassword();
-              } catch ( redirectError ) {
-                Message.showError('Unexpected situation, tenant redirection failed');
-              }
-              break;
             default:
               // Other common Error
-              await Utils.handleHttpUnexpectedError(this.centralServerProvider, error, 'authentication.resetPasswordUnexpectedError');
+              await Utils.handleHttpUnexpectedError(this.centralServerProvider, error, 'authentication.resetPasswordUnexpectedError', null, null, async () => this.resetPassword());
           }
         } else {
           Message.showError(I18n.t('authentication.resetPasswordUnexpectedError'));

--- a/src/screens/auth/reset-password/ResetPassword.tsx
+++ b/src/screens/auth/reset-password/ResetPassword.tsx
@@ -7,18 +7,19 @@ import { Keyboard, KeyboardAvoidingView, ScrollView, TextInput } from 'react-nat
 
 import computeFormStyleSheet from '../../../FormStyles';
 import BaseProps from '../../../types/BaseProps';
-import { HTTPError } from '../../../types/HTTPError';
 import Message from '../../../utils/Message';
 import Utils from '../../../utils/Utils';
 import BaseScreen from '../../base-screen/BaseScreen';
 import AuthHeader from '../AuthHeader';
 import computeStyleSheet from '../AuthStyles';
+import { TenantConnection } from '../../../types/Tenant';
 
 export interface Props extends BaseProps {}
 
 interface State {
   tenantSubDomain?: string;
   tenantName?: string;
+  tenantLogo?: string;
   hash?: string;
   password?: string;
   repeatPassword?: string;
@@ -63,9 +64,10 @@ export default class ResetPassword extends BaseScreen<Props, State> {
   public constructor(props: Props) {
     super(props);
     this.state = {
-      tenantSubDomain: Utils.getParamFromNavigation(this.props.navigation, 'tenantSubDomain', '') as string,
-      hash: Utils.getParamFromNavigation(this.props.navigation, 'hash', null) as string,
+      tenantSubDomain: Utils.getParamFromNavigation(this.props.route, 'tenantSubDomain', '') as string,
+      hash: Utils.getParamFromNavigation(this.props.route, 'hash', null) as string,
       tenantName: '',
+      tenantLogo: null,
       password: '',
       repeatPassword: '',
       loading: false,
@@ -81,16 +83,49 @@ export default class ResetPassword extends BaseScreen<Props, State> {
     super.setState(state, callback);
   };
 
-  public async componentDidMount() {
+  public async setTenantLogo(tenant: TenantConnection): Promise<void> {
+    try {
+      if (tenant) {
+        const tenantLogo = await this.centralServerProvider.getTenantLogoBySubdomain(tenant);
+        this.setState({tenantLogo});
+      }
+    } catch (error) {
+      switch ( error?.request?.status ) {
+        case StatusCodes.NOT_FOUND:
+          return null;
+        default:
+          await Utils.handleHttpUnexpectedError(
+            this.centralServerProvider,
+            error,
+            null,
+            null,
+            null,
+            async (redirectedTenant: TenantConnection) => this.setTenantLogo(redirectedTenant)
+          );
+          break;
+      }
+    }
+    return null;
+  }
+
+  public async componentDidMount(): Promise<void> {
     // Call parent
     await super.componentDidMount();
     // Init
     const tenant = await this.centralServerProvider.getTenant(this.state.tenantSubDomain);
+    await this.setTenantLogo(tenant);
     this.setState({
       tenantName: tenant ? tenant.name : ''
     });
     // Disable Auto Login
     this.centralServerProvider.setAutoLoginDisabled(true);
+  }
+
+  public async componentDidFocus(): Promise<void> {
+    super.componentDidFocus();
+    const tenantSubdomain = Utils.getParamFromNavigation(this.props.route, 'tenantSubDomain', this.state.tenantSubDomain) as string;
+    const tenant = await this.centralServerProvider.getTenant(tenantSubdomain);
+    await this.setTenantLogo(tenant);
   }
 
   public resetPassword = async () => {
@@ -134,6 +169,15 @@ export default class ResetPassword extends BaseScreen<Props, State> {
             case StatusCodes.NOT_FOUND:
               Message.showError(I18n.t('authentication.resetPasswordHashNotValid'));
               break;
+            case StatusCodes.MOVED_TEMPORARILY:
+              const newURLDomain = error?.response?.data?.errorDetailedMessage?.redirectDomain;
+              try {
+                await Utils.redirectTenant(newURLDomain, tenantSubDomain);
+                this.resetPassword();
+              } catch ( redirectError ) {
+                Message.showError('Unexpected situation, tenant redirection failed');
+              }
+              break;
             default:
               // Other common Error
               await Utils.handleHttpUnexpectedError(this.centralServerProvider, error, 'authentication.resetPasswordUnexpectedError');
@@ -149,9 +193,8 @@ export default class ResetPassword extends BaseScreen<Props, State> {
     const style = computeStyleSheet();
     const formStyle = computeFormStyleSheet();
     const commonColor = Utils.getCurrentCommonColor();
-    const { tenantName, loading, hidePassword, hideRepeatPassword } = this.state;
+    const { tenantName, loading, hidePassword, hideRepeatPassword, tenantLogo } = this.state;
     // Get logo
-    const tenantLogo = this.centralServerProvider?.getCurrentTenantLogo();
     return (
       <View style={style.container}>
         <ScrollView contentContainerStyle={style.scrollContainer}>

--- a/src/screens/auth/retrieve-password/RetrievePassword.tsx
+++ b/src/screens/auth/retrieve-password/RetrievePassword.tsx
@@ -14,6 +14,7 @@ import Utils from '../../../utils/Utils';
 import BaseScreen from '../../base-screen/BaseScreen';
 import AuthHeader from '../AuthHeader';
 import computeStyleSheet from '../AuthStyles';
+import { TenantConnection } from '../../../types/Tenant';
 
 export interface Props extends BaseProps {}
 
@@ -27,6 +28,7 @@ interface State {
   performRetrievePassword?: boolean;
   loading?: boolean;
   errorEmail?: Record<string, unknown>[];
+  tenantLogo?: null;
 }
 
 export default class RetrievePassword extends BaseScreen<Props, State> {
@@ -54,8 +56,34 @@ export default class RetrievePassword extends BaseScreen<Props, State> {
       captchaBaseUrl: null,
       captcha: null,
       loading: false,
-      performRetrievePassword: false
+      performRetrievePassword: false,
+      tenantLogo: null
     };
+  }
+
+  public async setTenantLogo(tenant: TenantConnection): Promise<void> {
+    try {
+      if (tenant) {
+        const tenantLogo = await this.centralServerProvider.getTenantLogoBySubdomain(tenant);
+        this.setState({tenantLogo});
+      }
+    } catch (error) {
+      switch ( error?.request?.status ) {
+        case StatusCodes.NOT_FOUND:
+          return null;
+        default:
+          await Utils.handleHttpUnexpectedError(
+            this.centralServerProvider,
+            error,
+            null,
+            null,
+            null,
+            async (redirectedTenant: TenantConnection) => this.setTenantLogo(redirectedTenant)
+          );
+          break;
+      }
+    }
+    return null;
   }
 
   public setState = (
@@ -65,11 +93,24 @@ export default class RetrievePassword extends BaseScreen<Props, State> {
     super.setState(state, callback);
   };
 
-  public async componentDidMount() {
+  public async componentDidFocus(): Promise<void> {
+    super.componentDidFocus();
+    const tenantSubDomain = Utils.getParamFromNavigation(this.props.route, 'tenantSubDomain', this.state.tenantSubDomain) as string;
+    const tenant = await this.centralServerProvider.getTenant(tenantSubDomain);
+    await this.setTenantLogo(tenant);
+    this.setState( {
+      tenantSubDomain,
+      tenantName: tenant.name
+    });
+
+  }
+
+  public async componentDidMount(): Promise<void> {
     // Call parent
     await super.componentDidMount();
-    // Init
     const tenant = await this.centralServerProvider.getTenant(this.state.tenantSubDomain);
+    // Init
+    await this.setTenantLogo(tenant);
     this.setState({
       tenantName: tenant ? tenant.name : '',
       captchaSiteKey: this.centralServerProvider.getCaptchaSiteKey(),
@@ -80,13 +121,13 @@ export default class RetrievePassword extends BaseScreen<Props, State> {
   }
 
   public onCaptchaCreated = (captcha: string) => {
-    this.setState({ captcha }, this.state.performRetrievePassword ? () => this.retrievePassword() : () => {});
+    this.setState({ captcha }, this.state.performRetrievePassword ? async () => this.retrievePassword() : () => {});
   };
 
   public retrievePassword = async () => {
     // Check field
     const { tenantSubDomain, email, captcha } = this.state;
-    const formIsValid = Utils.validateInput(this, this.formValidationDef)
+    const formIsValid = Utils.validateInput(this, this.formValidationDef);
     // Force captcha regeneration for next signUp click
     if (formIsValid && captcha) {
       try {
@@ -141,9 +182,8 @@ export default class RetrievePassword extends BaseScreen<Props, State> {
     const style = computeStyleSheet();
     const formStyle = computeFormStyleSheet();
     const commonColor = Utils.getCurrentCommonColor();
-    const { loading, captcha, tenantName, captchaSiteKey, captchaBaseUrl } = this.state;
+    const { loading, captcha, tenantName, captchaSiteKey, captchaBaseUrl, tenantLogo } = this.state;
     // Get logo
-    const tenantLogo = this.centralServerProvider?.getCurrentTenantLogo();
     return (
       <View style={style.container}>
         <ScrollView contentContainerStyle={style.scrollContainer}>
@@ -175,7 +215,7 @@ export default class RetrievePassword extends BaseScreen<Props, State> {
               {loading ? (
                 <Spinner style={formStyle.spinner} color="grey" />
               ) : (
-                <Button primary block style={formStyle.button} onPress={async () => this.setState({loading: true, performRetrievePassword: true, captcha: null})}>
+                <Button primary block style={formStyle.button} onPress={this.onRetrievePassword.bind(this)}>
                   <Text style={formStyle.buttonText} uppercase={false}>
                     {I18n.t('authentication.retrievePassword')}
                   </Text>
@@ -186,7 +226,7 @@ export default class RetrievePassword extends BaseScreen<Props, State> {
           {captchaSiteKey && captchaBaseUrl && !captcha && (
             <ReactNativeRecaptchaV3
               action="ResetPassword"
-              onHandleToken={(captcha) => this.onCaptchaCreated(captcha)}
+              onHandleToken={this.onCaptchaCreated.bind(this)}
               url={captchaBaseUrl}
               siteKey={captchaSiteKey}
             />
@@ -203,5 +243,9 @@ export default class RetrievePassword extends BaseScreen<Props, State> {
         </Footer>
       </View>
     );
+  }
+
+  private onRetrievePassword(): void {
+    this.setState({loading: true, performRetrievePassword: true, captcha: null});
   }
 }

--- a/src/screens/auth/retrieve-password/RetrievePassword.tsx
+++ b/src/screens/auth/retrieve-password/RetrievePassword.tsx
@@ -169,7 +169,7 @@ export default class RetrievePassword extends BaseScreen<Props, State> {
               break;
             default:
               // Other common Error
-              await Utils.handleHttpUnexpectedError(this.centralServerProvider, error, 'authentication.resetPasswordUnexpectedError');
+              await Utils.handleHttpUnexpectedError(this.centralServerProvider, error, 'authentication.resetPasswordUnexpectedError', null, null, async () => this.retrievePassword());
           }
         } else {
           Message.showError(I18n.t('authentication.resetPasswordUnexpectedError'));

--- a/src/screens/auth/sign-up/SignUp.tsx
+++ b/src/screens/auth/sign-up/SignUp.tsx
@@ -244,7 +244,7 @@ export default class SignUp extends BaseScreen<Props, State> {
               break;
             default:
               // Other common Error
-              await Utils.handleHttpUnexpectedError(this.centralServerProvider, error, 'authentication.registerUnexpectedError');
+              await Utils.handleHttpUnexpectedError(this.centralServerProvider, error, 'authentication.registerUnexpectedError', null, null, async () => this.signUp());
           }
         } else {
           Message.showError(I18n.t('authentication.registerUnexpectedError'));

--- a/src/screens/charging-stations/list/ChargingStations.tsx
+++ b/src/screens/charging-stations/list/ChargingStations.tsx
@@ -136,7 +136,7 @@ export default class ChargingStations extends BaseAutoRefreshScreen<Props, State
       let chargingStations: DataResult<ChargingStation>;
       const { filters, showMap } = this.state;
       const currentLocation = await Utils.getUserCurrentLocation();
-      const projectFields = 'id|coordinates|inactive|connectors.connectorId|connectors.coordinates|connectors.status|siteArea.siteID'
+      const projectFields = 'id|coordinates|inactive|connectors.connectorId|connectors.coordinates|connectors.status|siteArea.siteID';
       try {
         const params = {
           Search: searchText,

--- a/src/screens/sidebar/SideBar.tsx
+++ b/src/screens/sidebar/SideBar.tsx
@@ -27,6 +27,7 @@ interface State {
   updateDate?: string;
   showAppUpdateDialog?: boolean;
   appVersion?: CheckVersionResponse;
+  tenantLogo?: string;
 }
 
 export default class SideBar extends React.Component<Props, State> {
@@ -58,15 +59,17 @@ export default class SideBar extends React.Component<Props, State> {
     super.setState(state, callback);
   };
 
-  public async componentDidMount() {
+  public async componentDidMount(): Promise<void> {
     this.centralServerProvider = await ProviderFactory.getProvider();
     this.securityProvider = this.centralServerProvider?.getSecurityProvider();
     await this.getUpdateDate();
+    const tenantLogo = await this.centralServerProvider.getCurrentTenantLogo();
+    this.setState({tenantLogo});
     // Init User (delay it)
     this.refresh();
   }
 
-  public componentWillUnmount() {
+  public componentWillUnmount(): void {
     this.componentFocusUnsubscribe?.();
     this.componentBlurUnsubscribe?.();
   }
@@ -117,10 +120,9 @@ export default class SideBar extends React.Component<Props, State> {
   public render() {
     const style = computeStyleSheet();
     const commonColor = Utils.getCurrentCommonColor();
-    const { userToken, tenantName, isComponentOrganizationActive, showAppUpdateDialog, appVersion } = this.state;
+    const { userToken, tenantName, isComponentOrganizationActive, showAppUpdateDialog, appVersion, tenantLogo } = this.state;
     const user = { firstName: userToken?.firstName, name: userToken?.name, id: userToken?.id } as User;
     // Get logo
-    const tenantLogo = this.centralServerProvider?.getCurrentTenantLogo();
     return (
       <SafeAreaView style={style.sidebar}>
         <View style={style.header}>

--- a/src/types/RequestError.tsx
+++ b/src/types/RequestError.tsx
@@ -3,9 +3,9 @@ export interface RequestError extends Error {
     status: number;
   };
   response?: {
-    data: Record<string, any>
+    data: Record<string, any>;
   };
-  config? : {
-    data: string
+  config?: {
+    data: string;
   };
 }

--- a/src/utils/Utils.tsx
+++ b/src/utils/Utils.tsx
@@ -705,7 +705,11 @@ export default class Utils {
             const newURLDomain = errorDetailedMessage?.redirectDomain;
             const subdomain = errorDetailedMessage?.subdomain;
             const redirectTenant = await this.redirectTenant(newURLDomain, subdomain);
-            redirectCallback?.(redirectTenant);
+            try {
+              redirectCallback?.(redirectTenant);
+            } catch ( error ) {
+              Message.showWarning('This organisation has been moved to a new server, please try again');
+            }
             if (centralServerProvider.isUserConnected()) {
               const tenantSubDomain = centralServerProvider.getUserTenant()?.subdomain;
               Message.showWarning(I18n.t('general.userOrTenantUpdated'));

--- a/src/utils/Utils.tsx
+++ b/src/utils/Utils.tsx
@@ -977,7 +977,7 @@ export default class Utils {
   public static computeMaxBoundaryDistanceKm(region: Region) {
     if (region) {
       const height = region.latitudeDelta * 111;
-      const width = region.longitudeDelta * 40075 * Math.cos(region.latitude) / 360
+      const width = region.longitudeDelta * 40075 * Math.cos(region.latitude) / 360;
       return Math.sqrt(height**2 + width**2)/2 * 1000;
     }
     return null;
@@ -1030,7 +1030,7 @@ export default class Utils {
     }
   }
 
-  public static async getAllEndpoints() : Promise<EndpointCloud[]> {
+  public static async getAllEndpoints(): Promise<EndpointCloud[]> {
     const userEndpoints = await SecuredStorage.getEndpoints() || [];
     const staticEndpoints = Configuration.getEndpoints() || [];
     return [...userEndpoints, ...staticEndpoints];


### PR DESCRIPTION
Redirection feature:
1. Check MOVED_TEMPORARILY 
2. Use of a callback to retry actions when redirect received from server
3. Retry on tenant logo fetch for all 4 pages e.g. Login, ResetPassword, SignUp and RetrievePassword
4. Securize redirect callback by  try catch displaying a generic message when callback failed (e.g. for an uncatched error) and inviting the user to try again. The message reads: 'This organisation has been moved to a new server, please try again'
5. Retry on click for all 4 pages e.g. Login, ResetPassword, SignUp and RetrievePassword to be sure we cover all cases.
6. Fixed tenant logo fetch (fetch on focus and mount for every screen + sidebar)
7. Made EULA fetch indpendant from tenant (no need to select an organization anymore)

TESTS: 
1. Create a tenant with old endpoint and select it -> focus on Login page redirects on logo fetch
2. If tenant with old endpoint already selected, redirection occurs when opening Retrieve Password, SignUp, Reset Password or when clicking on any button.