### PR TITLE
Fixed release build

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -21,7 +21,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath('com.android.tools.build:gradle:7.3.1')
+        classpath('com.android.tools.build:gradle:7.2.1')
         classpath("com.facebook.react:react-native-gradle-plugin")
         classpath("de.undercouch:gradle-download-task:5.0.1")
         // Required for Firebase

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,7 +79,7 @@
         "react-native-svg": "^13.6.0",
         "react-native-vector-icons": "^9.2.0",
         "react-native-webview": "^11.23.1",
-        "rn-secure-storage": "github:sap-labs-france/rn-secure-storage",
+        "rn-secure-storage": "^2.0.8",
         "tslib": "^2.4.1",
         "validate.js": "^0.13.1"
       },
@@ -26810,9 +26810,9 @@
       }
     },
     "node_modules/rn-secure-storage": {
-      "version": "2.0.3",
-      "resolved": "git+ssh://git@github.com/sap-labs-france/rn-secure-storage.git#bf3de3f7a8ee8e732a35f2f4ebd54063bc25d33e",
-      "license": "MIT"
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/rn-secure-storage/-/rn-secure-storage-2.0.8.tgz",
+      "integrity": "sha512-byk51qL+4GNfaBxs30TZsv3l1vXRry8Pck3q2xzwNUYfSyEdTn8NnCW2l8hOog0XEGCJdfbeFy5+EgCVnMsRAQ=="
     },
     "node_modules/rsvp": {
       "version": "4.8.5",
@@ -50694,8 +50694,9 @@
       }
     },
     "rn-secure-storage": {
-      "version": "git+ssh://git@github.com/sap-labs-france/rn-secure-storage.git#bf3de3f7a8ee8e732a35f2f4ebd54063bc25d33e",
-      "from": "rn-secure-storage@github:sap-labs-france/rn-secure-storage"
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/rn-secure-storage/-/rn-secure-storage-2.0.8.tgz",
+      "integrity": "sha512-byk51qL+4GNfaBxs30TZsv3l1vXRry8Pck3q2xzwNUYfSyEdTn8NnCW2l8hOog0XEGCJdfbeFy5+EgCVnMsRAQ=="
     },
     "rsvp": {
       "version": "4.8.5",

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "react-native-svg": "^13.6.0",
     "react-native-vector-icons": "^9.2.0",
     "react-native-webview": "^11.23.1",
-    "rn-secure-storage": "github:sap-labs-france/rn-secure-storage",
+    "rn-secure-storage": "^2.0.8",
     "tslib": "^2.4.1",
     "validate.js": "^0.13.1"
   },


### PR DESCRIPTION
- Use specific version of gradle build tools (7.2.1 istd. of 7.3.1)
- Remove usage of local fork for rn-secure-storage and use last public version instead