### PR TITLE
Prevent drawer from opening where it shouldn't

### DIFF
--- a/src/components/charging-station/connector/ChargingStationConnectorComponent.tsx
+++ b/src/components/charging-station/connector/ChargingStationConnectorComponent.tsx
@@ -145,7 +145,7 @@ export default class ChargingStationConnectorComponent extends React.Component<P
     const { connector, navigation, chargingStation, onNavigate, listed } = this.props;
     return (
       <TouchableOpacity
-        style={[style.container, listed && style.borderedTopContainer]}
+        style={[style.container, listed && style.borderedBottomContainer]}
         disabled={chargingStation.inactive || !listed}
         onPress={() => {
           if (onNavigate) {

--- a/src/components/charging-station/connector/ChargingStationConnectorComponentStyles.tsx
+++ b/src/components/charging-station/connector/ChargingStationConnectorComponentStyles.tsx
@@ -12,12 +12,11 @@ export default function computeStyleSheet(): StyleSheet.NamedStyles<any> {
       width: '100%',
       justifyContent: 'center',
       alignItems: 'stretch',
-      borderStyle: 'solid',
-      borderBottomWidth: 1,
-      borderColor: commonColor.listBorderColor
+      borderStyle: 'solid'
     },
-    borderedTopContainer: {
-      borderTopColor: commonColor.listBorderColor
+    borderedBottomContainer: {
+      borderBottomWidth: 1,
+      borderBottomColor: commonColor.listBorderColor
     },
     connectorContainer: {
       flexDirection: 'row',

--- a/src/screens/base-screen/BaseScreen.tsx
+++ b/src/screens/base-screen/BaseScreen.tsx
@@ -56,7 +56,7 @@ export default class BaseScreen<P, S> extends React.Component<Props, State> {
     this.backHandler?.remove();
   }
 
-  private setDrawerStatus(): void {
+  protected setDrawerStatus(): void {
     const drawer = this.props?.navigation?.getParent('drawer');
     drawer?.setOptions({
       swipeEnabled: this.canOpenDrawer

--- a/src/screens/base-screen/SelectableList.tsx
+++ b/src/screens/base-screen/SelectableList.tsx
@@ -95,5 +95,11 @@ export default class SelectableList<T extends ListItem> extends BaseScreen<Selec
     await this.refresh();
     // Hide spinner
     this.setState({ refreshing: false });
-  };
+  }
+
+  protected setDrawerStatus() {
+    if (!this.props.isModal) {
+      super.setDrawerStatus();
+    }
+  }
 }


### PR DESCRIPTION
- When opening a modal, the drawer options were changed causing drawer to be openable where it wasn't supposed to be